### PR TITLE
（再送）不正なメールアドレスはエラーになるテスト

### DIFF
--- a/src/spec/models/food_enquete_spec.rb
+++ b/src/spec/models/food_enquete_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe FoodEnquete, type: :model do
     end
   end
 
+  describe 'メールアドレスの形式' do
+    context '不正なメールアドレスの場合' do
+      it 'エラーになること' do
+        new_enquete = FoodEnquete.new
+        new_enquete.mail = 'taro.tanaka'
+        expect(new_enquete).not_to be_valid
+        expect(new_enquete.errors[:mail]).to include(I18n.t('errors.messages.invalid'))
+      end
+    end
+  end
+
   describe 'アンケート回答時の条件' do
     context 'メールアドレスを確認すること' do
       it '同じメールアドレスで再び回答できないこと' do


### PR DESCRIPTION
- ブランチ名を'rspec'に変更
- 不正なメールアドレスはエラーになる