### PR TITLE
It

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ src/.byebug_history
 src/config/master.key
 
 src/db/mysql_data
+
+src/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,17 +8,6 @@ services:
       MYSQL_ROOT_PASSWORD: password
       TZ: Asia/Tokyo
 
-  test-db: #Rspecでのテスト実行用のコンテナ
-    image: mysql:5.7
-    ports:
-      - '4306:3306'    #開発用とはポート番号を別にする
-    environment:    #接続情報は開発のものと一応分けます
-      MYSQL_DATABASE: <%= ENV.fetch('TEST_DATABASE') %>
-      MYSQL_ROOT_PASSWORD: <%= ENV.fetch('TEST_ROOTPASS') %>
-      MYSQL_USER: <%= ENV.fetch('TEST_USERNAME') %>
-      MYSQL_PASSWORD: <%= ENV.fetch('TEST_USERPASS') %>
-      TZ: Asia/Tokyo
-
   web:
     build: .
     command: bundle exec rails s -p 3000 -b '0.0.0.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,18 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       TZ: Asia/Tokyo
+
+  test-db: #Rspecでのテスト実行用のコンテナ
+    image: mysql:5.7
+    ports:
+      - '4306:3306'    #開発用とはポート番号を別にする
+    environment:    #接続情報は開発のものと一応分けます
+      MYSQL_DATABASE: <%= ENV.fetch('TEST_DATABASE') %>
+      MYSQL_ROOT_PASSWORD: <%= ENV.fetch('TEST_ROOTPASS') %>
+      MYSQL_USER: <%= ENV.fetch('TEST_USERNAME') %>
+      MYSQL_PASSWORD: <%= ENV.fetch('TEST_USERPASS') %>
+      TZ: Asia/Tokyo
+
   web:
     build: .
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
@@ -16,3 +28,11 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - chrome
+    environment:
+      SELENIUM_DRIVER_URL: http://chrome:4444/wd/hub  #追加、どのコンテナのブラウザを使用するか指定
+
+  chrome:    #Chromeでのテスト実行用コンテナ
+    image: selenium/standalone-chrome    #Chromeがインストールされたイメージ
+    ports:
+      - '4444:4444'

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -37,9 +37,14 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-
   gem 'rspec-rails', '~> 3.8'
   gem 'factory_bot_rails', '~> 5.0'
+end
+
+group :test do
+  gem 'capybara', '~> 3.28'
+  gem 'selenium-webdriver', '~> 3.142'
+  gem 'webdrivers', '~> 4.1'
 end
 
 group :development do

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -34,6 +34,8 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'dotenv'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -42,12 +42,24 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     bindex (0.8.1)
     bootsnap (1.9.3)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    capybara (3.36.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -75,6 +87,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
@@ -85,6 +98,7 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
+    public_suffix (4.0.6)
     puma (3.12.6)
     racc (1.6.0)
     rack (2.2.3)
@@ -118,6 +132,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    regexp_parser (2.2.0)
     rspec-core (3.9.3)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.4)
@@ -136,6 +151,7 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.4)
     ruby_dep (1.5.0)
+    rubyzip (2.3.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -147,6 +163,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -173,9 +192,15 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.7.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (> 3.141, < 5.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -183,6 +208,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
+  capybara (~> 3.28)
   factory_bot_rails (~> 5.0)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
@@ -191,12 +217,14 @@ DEPENDENCIES
   rails (~> 5.2.5)
   rspec-rails (~> 3.8)
   sass-rails (~> 5.0)
+  selenium-webdriver (~> 3.142)
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers (~> 4.1)
 
 RUBY VERSION
    ruby 2.7.5p203

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
     erubi (1.10.0)
     execjs (2.8.1)
     factory_bot (5.2.0)
@@ -209,6 +210,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   capybara (~> 3.28)
+  dotenv
   factory_bot_rails (~> 5.0)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/src/config/database.yml
+++ b/src/config/database.yml
@@ -26,8 +26,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: mysql_test
-  host: test-db
+  database: app_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/src/config/database.yml
+++ b/src/config/database.yml
@@ -26,7 +26,8 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: app_test
+  database: mysql_test
+  host: test-db
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/src/spec/spec_helper.rb
+++ b/src/spec/spec_helper.rb
@@ -13,7 +13,14 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'capybara/rspec'
+
 RSpec.configure do |config|
+  # ブラウザにchromeを指定
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :chrome, screen_size: [1280, 960]
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/src/spec/spec_helper.rb
+++ b/src/spec/spec_helper.rb
@@ -16,11 +16,33 @@
 
 require 'capybara/rspec'
 
+Capybara.register_driver :remote_chrome do |app|
+  url = "http://chrome:4444/wd/hub"
+  caps = ::Selenium::WebDriver::Remote::Capabilities.chrome(
+    "goog:chromeOptions" => {
+      "args" => [
+        "no-sandbox",
+        "headless",
+        "disable-gpu",
+        "window-size=1680,1050"
+      ]
+    }
+  )
+  Capybara::Selenium::Driver.new(app, browser: :remote, url: url, desired_capabilities: caps)
+end
+
 RSpec.configure do |config|
-  # ブラウザにchromeを指定
+  # config.before(:each, type: :system) do
+  #   driven_by :rack_test
+  # end
+
   config.before(:each, type: :system) do
-    driven_by :selenium, using: :chrome, screen_size: [1280, 960]
+    driven_by :remote_chrome
+    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
+    Capybara.server_port = 3300 #portは3000以外を指定すること
+    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
   end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/src/spec/system/food_enquetes_spec.rb
+++ b/src/spec/system/food_enquetes_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe "FoodEnquete", type: :system do
+  describe '正常' do
+    context 'アンケートに回答する' do
+      it '回答できること' do
+        enquete = FactoryBot.create(:food_enquete_tanaka)
+        visit "/food_enquetes/new"
+        fill_in 'お名前', with: enquete.name
+        fill_in 'メールアドレス', with: enquete.mail
+        fill_in '年齢', with: enquete.age
+        select enquete.food_name, from: 'お召し上がりになった料理'
+        choose "food_enquete_score_#{enquete.score}"
+        fill_in ' ご意見・ご要望', with: enquete.request
+        select enquete.present_name, from: 'ご希望のプレゼント'
+
+        sleep2 #2秒止める動作だが本来は不要
+        chick_button '登録する'
+
+        expect(page).to have_content 'ご回答ありがとうございました'
+        expect(page).to have_content 'お名前: 田中 太郎'
+        expect(page).to have_content 'メールアドレス: taro.tanaka@example.com'
+        expect(page).to have_content '年齢: 25'
+        expect(page).to have_content 'お召し上がりになった料理: やきそば'
+        expect(page).to have_content '満足度: 良い'
+        expect(page).to have_content 'ご意見・ご要望: おいしかったです。'
+        expect(page).to have_content 'ご希望のプレゼント: 【10名に当たる】ビール飲み放題'
+
+        sleep5 #5秒止めるが本来は不要
+      end
+    end
+  end
+end

--- a/src/spec/system/food_enquetes_spec.rb
+++ b/src/spec/system/food_enquetes_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "FoodEnquete", type: :system do
         fill_in '年齢', with: enquete.age
         select enquete.food_name, from: 'お召し上がりになった料理'
         choose "food_enquete_score_#{enquete.score}"
-        fill_in ' ご意見・ご要望', with: enquete.request
+        fill_in 'food_enquete[request]', with: enquete.request
         select enquete.present_name, from: 'ご希望のプレゼント'
 
         sleep2 #2秒止める動作だが本来は不要

--- a/src/spec/system/food_enquetes_spec.rb
+++ b/src/spec/system/food_enquetes_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe "FoodEnquete", type: :system do
         fill_in 'food_enquete[request]', with: enquete.request
         select enquete.present_name, from: 'ご希望のプレゼント'
 
-        sleep2 #2秒止める動作だが本来は不要
-        chick_button '登録する'
+        click_button '登録する'
 
         expect(page).to have_content 'ご回答ありがとうございました'
         expect(page).to have_content 'お名前: 田中 太郎'
@@ -25,8 +24,6 @@ RSpec.describe "FoodEnquete", type: :system do
         expect(page).to have_content '満足度: 良い'
         expect(page).to have_content 'ご意見・ご要望: おいしかったです。'
         expect(page).to have_content 'ご希望のプレゼント: 【10名に当たる】ビール飲み放題'
-
-        sleep5 #5秒止めるが本来は不要
       end
     end
   end


### PR DESCRIPTION
- 結合テスト用に編集
- dotenvをインストール
- webブラウザの入力テストを実装
- Capybara使用可能なように、dockerにchromeコンテナを追加
- ブラウザは立ち上がらないがバックグラウンドでテスト実施する
